### PR TITLE
Fix de.json

### DIFF
--- a/languages/de.json
+++ b/languages/de.json
@@ -23,7 +23,7 @@
             },
             "customConversionOriginalLabelsSmall": {
                 "name": "Originales Textlabel: Kleine Maßeinheit",
-                "hint": "Das originale Textlabel für die kleine Maßeinheit, welches das Modul konvertieren soll. Dies ist das Label, welches du derzeit z.B. beim Maßstab siehst. Du kannst kommagetrennt mehrere Labels angeben (ohne Leerzeichen). Wenn du z.B. Fuß konvertieren willst, könnte eine mögliche Eingabe 'ft,feet,ft.' sein. Dies hängt von deinen Einstellungen in der Szene ab.",
+                "hint": "Das originale Textlabel für die kleine Maßeinheit, welches das Modul konvertieren soll. Dies ist das Label, welches du derzeit z.B. beim Maßstab siehst. Du kannst kommagetrennt mehrere Labels angeben (ohne Leerzeichen). Wenn du z.B. Fuß konvertieren willst, könnte eine mögliche Eingabe 'ft,feet,ft.' sein. Dies hängt von deinen Einstellungen in der Szene ab."
             },
             "customConversionOriginalLabelsBig": {
                 "name": "Originales Textlabel: Große Maßeinheit",


### PR DESCRIPTION
Hi,

while loading foundry I got an error about invalid json: SyntaxError: JSON.parse: expected double-quoted property name at line 27 column 13 of the JSON data

Overall this is not a big issue, it just means that the translations are not loaded, this should fix this.